### PR TITLE
Addresses Issue #43 - Argument must be a string

### DIFF
--- a/lib/markdown-mindmap-view.coffee
+++ b/lib/markdown-mindmap-view.coffee
@@ -47,7 +47,7 @@ getSVG = ({ body, width, height, viewbox }) ->
   """
 
 transformLinks = (headings, filepath) ->
-  dir = path.dirname(filepath)
+  dir = path.dirname(Script(filepath))
   result = []
   headings.forEach (h) ->
     h.filepath = filepath


### PR DESCRIPTION
Problem in latest versions reports "Argument to path.dirname must be a string"

Modifed argument to refer to filepath as Script(filepath)